### PR TITLE
Add link to stdlib docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Artifacts.jl
 
 This is a wrapper package meant to bridge the gap for packages that want to use the [`Artifacts`](https://github.com/JuliaLang/julia/tree/master/stdlib/Artifacts) as a dependency within packages that still support Julia versions older than 1.6.
+
+## Documentation
+
+Check out the [Artifacts standard library docs](https://docs.julialang.org/en/v1/stdlib/Artifacts/).


### PR DESCRIPTION
Searching online for "Artifacts.jl" brings you here, although what I really wanted was to learn about the Artifacts standard library. This is already explained in the README of this repo, but by adding a link to the stdlib docs, we can send people to where they should go if they are not looking for the compat package.